### PR TITLE
Add Wikidata IDs to title and author ref attributes in level1 XML files

### DIFF
--- a/level1/SLV00024.xml
+++ b/level1/SLV00024.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Od pluga do krone : edicija ELTeC</title>
-            <author ref="viaf:84381657">Bedenek, Jakob (1850-1916)</author>
+            <title ref="wikidata:Q111072078">Od pluga do krone : edicija ELTeC</title>
+            <author ref="viaf:84381657 wikidata:Q17379521">Bedenek, Jakob (1850-1916)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00048.xml
+++ b/level1/SLV00048.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>V krvi : edicija ELTeC</title>
-            <author ref="viaf:51812691">Govekar, Fran (1871-1949)</author>
+            <title ref="wikidata:Q17396599">V krvi : edicija ELTeC</title>
+            <author ref="viaf:51812691 wikidata:Q12788999">Govekar, Fran (1871-1949)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00058.xml
+++ b/level1/SLV00058.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Ciklamen : edicija ELTeC</title>
-            <author ref="viaf:34746806">Kersnik, Janko (1852-1897)</author>
+            <title ref="wikidata:Q5119917">Ciklamen : edicija ELTeC</title>
+            <author ref="viaf:34746806 wikidata:Q2474110">Kersnik, Janko (1852-1897)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00072.xml
+++ b/level1/SLV00072.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Kam plovemo : edicija ELTeC</title>
-            <author ref="viaf:62359223">Meško, Ksaver (1874-1964)</author>
+            <title ref="wikidata:Q111071910">Kam plovemo : edicija ELTeC</title>
+            <author ref="viaf:62359223 wikidata:Q1294447">Meško, Ksaver (1874-1964)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00090.xml
+++ b/level1/SLV00090.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Spletke : edicija ELTeC</title>
+            <title ref="wikidata:Q111072131">Spletke : edicija ELTeC</title>
             <author ref="conor:311191651">Štrukelj, Ivan (1869-1948)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>

--- a/level1/SLV00092.xml
+++ b/level1/SLV00092.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Zmota in povrat : edicija ELTeC</title>
+            <title ref="wikidata:Q111072207">Zmota in povrat : edicija ELTeC</title>
             <author ref="conor:311191651">Štrukelj, Ivan (1869-1948)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>

--- a/level1/SLV00094.xml
+++ b/level1/SLV00094.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Pomladanski vetrovi : edicija ELTeC</title>
-            <author ref="viaf:10824798">Bartel, Anton (1853-1938)</author>
+            <title ref="wikidata:Q111072101">Pomladanski vetrovi : edicija ELTeC</title>
+            <author ref="viaf:10824798 wikidata:Q17349268">Bartel, Anton (1853-1938)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00098.xml
+++ b/level1/SLV00098.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Luteranci : edicija ELTeC</title>
-            <author ref="viaf:172847595">Koder, Anton (1851-1918)</author>
+            <title ref="wikidata:Q111071955">Luteranci : edicija ELTeC</title>
+            <author ref="viaf:172847595 wikidata:Q12784821">Koder, Anton (1851-1918)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00099.xml
+++ b/level1/SLV00099.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Marjetica : edicija ELTeC</title>
-            <author ref="viaf:172847595">Koder, Anton (1851-1918)</author>
+            <title ref="wikidata:Q17395836">Marjetica : edicija ELTeC</title>
+            <author ref="viaf:172847595 wikidata:Q12784821">Koder, Anton (1851-1918)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00103.xml
+++ b/level1/SLV00103.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Zvezdana : edicija ELTeC</title>
-            <author ref="viaf:172847595">Koder, Anton (1851-1918)</author>
+            <title ref="wikidata:Q111072211">Zvezdana : edicija ELTeC</title>
+            <author ref="viaf:172847595 wikidata:Q12784821">Koder, Anton (1851-1918)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00111.xml
+++ b/level1/SLV00111.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Pegam in Lambergar : edicija ELTeC</title>
-            <author ref="viaf:61405029">Detela, Fran (1850-1926)</author>
+            <title ref="wikidata:Q20520485">Pegam in Lambergar : edicija ELTeC</title>
+            <author ref="viaf:61405029 wikidata:Q5478131">Detela, Fran (1850-1926)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00112.xml
+++ b/level1/SLV00112.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Veliki grof : edicija ELTeC</title>
-            <author ref="viaf:61405029">Detela, Fran (1850-1926)</author>
+            <title ref="wikidata:Q111072182">Veliki grof : edicija ELTeC</title>
+            <author ref="viaf:61405029 wikidata:Q5478131">Detela, Fran (1850-1926)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00122.xml
+++ b/level1/SLV00122.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Žalost in veselje : edicija ELTeC</title>
-            <author ref="viaf:305144647704454014387">Podmilšak, Josip (1845-1874)</author>
+            <title ref="wikidata:Q111072204">Žalost in veselje : edicija ELTeC</title>
+            <author ref="viaf:305144647704454014387 wikidata:Q12792723">Podmilšak, Josip (1845-1874)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00126.xml
+++ b/level1/SLV00126.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Ljudska osveta : edicija ELTeC</title>
-            <author ref="viaf:55376955">Jaklič, Fran (1868-1937)</author>
+            <title ref="wikidata:Q111071951">Ljudska osveta : edicija ELTeC</title>
+            <author ref="viaf:55376955 wikidata:Q12789003">Jaklič, Fran (1868-1937)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00132.xml
+++ b/level1/SLV00132.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Gorski potoki : edicija ELTeC</title>
-            <author ref="viaf:24474637">Maselj Podlimbarski, Fran (1852-1917)</author>
+            <title ref="wikidata:Q111071846">Gorski potoki : edicija ELTeC</title>
+            <author ref="viaf:24474637 wikidata:Q4283778">Maselj Podlimbarski, Fran (1852-1917)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00135.xml
+++ b/level1/SLV00135.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Gospa s pristave : edicija ELTeC</title>
-            <author ref="viaf:68374219">Janežič-Kraljev, Ivan (1855-1922)</author>
+            <title ref="wikidata:Q111071849">Gospa s pristave : edicija ELTeC</title>
+            <author ref="viaf:68374219 wikidata:Q22964853">Janežič-Kraljev, Ivan (1855-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00136.xml
+++ b/level1/SLV00136.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>4000 : edicija ELTeC</title>
-            <author ref="viaf:100298803">Tavčar, Ivan (1851-1923)</author>
+            <title ref="wikidata:Q17391350">4000 : edicija ELTeC</title>
+            <author ref="viaf:100298803 wikidata:Q700898">Tavčar, Ivan (1851-1923)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00172.xml
+++ b/level1/SLV00172.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Milko Vogrin : edicija ELTeC</title>
-            <author ref="viaf:93569857">Sket, Jakob (1852-1912)</author>
+            <title ref="wikidata:Q111072014">Milko Vogrin : edicija ELTeC</title>
+            <author ref="viaf:93569857 wikidata:Q1679356">Sket, Jakob (1852-1912)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00174.xml
+++ b/level1/SLV00174.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Abadon : edicija ELTeC</title>
-            <author ref="viaf:53025627">Mencinger, Janez (1838-1912)</author>
+            <title ref="wikidata:Q4663232">Abadon : edicija ELTeC</title>
+            <author ref="viaf:53025627 wikidata:Q14915276">Mencinger, Janez (1838-1912)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00187.xml
+++ b/level1/SLV00187.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Agitator : edicija ELTeC</title>
-            <author ref="viaf:34746806">Kersnik, Janko (1852-1897)</author>
+            <title ref="wikidata:Q12784019">Agitator : edicija ELTeC</title>
+            <author ref="viaf:34746806 wikidata:Q2474110">Kersnik, Janko (1852-1897)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00194.xml
+++ b/level1/SLV00194.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Na Žerinjah : edicija ELTeC</title>
-            <author ref="viaf:34746806">Kersnik, Janko (1852-1897)</author>
+            <title ref="wikidata:Q6956480">Na Žerinjah : edicija ELTeC</title>
+            <author ref="viaf:34746806 wikidata:Q2474110">Kersnik, Janko (1852-1897)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00216.xml
+++ b/level1/SLV00216.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Rokovnjači : edicija ELTeC</title>
-            <author ref="viaf:54483391">Jurčič, Josip (1844-1881)</author>
+            <title ref="wikidata:Q7360082">Rokovnjači : edicija ELTeC</title>
+            <author ref="viaf:54483391 wikidata:Q3491574">Jurčič, Josip (1844-1881)</author>
             <author ref="viaf:34746806">Kersnik, Janko (1852-1897)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>

--- a/level1/SLV00217.xml
+++ b/level1/SLV00217.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Slovenski svetec in učitelj : edicija ELTeC</title>
-            <author ref="viaf:54483391">Jurčič, Josip (1844-1881)</author>
+            <title ref="wikidata:Q7541900">Slovenski svetec in učitelj : edicija ELTeC</title>
+            <author ref="viaf:54483391 wikidata:Q3491574">Jurčič, Josip (1844-1881)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00227.xml
+++ b/level1/SLV00227.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Beatin dnevnik : edicija ELTeC</title>
-            <author ref="viaf:307425009">Pesjak, Luiza (1828-1898)</author>
+            <title ref="wikidata:Q17395936">Beatin dnevnik : edicija ELTeC</title>
+            <author ref="viaf:307425009 wikidata:Q12795307">Pesjak, Luiza (1828-1898)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00231.xml
+++ b/level1/SLV00231.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Arabela : edicija ELTeC</title>
-            <author ref="viaf:260393202">Pajk, Pavlina (1854-1901)</author>
+            <title ref="wikidata:Q12785045">Arabela : edicija ELTeC</title>
+            <author ref="viaf:260393202 wikidata:Q14428732">Pajk, Pavlina (1854-1901)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00234.xml
+++ b/level1/SLV00234.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Dušne borbe : edicija ELTeC</title>
-            <author ref="viaf:260393202">Pajk, Pavlina (1854-1901)</author>
+            <title ref="wikidata:Q111071822">Dušne borbe : edicija ELTeC</title>
+            <author ref="viaf:260393202 wikidata:Q14428732">Pajk, Pavlina (1854-1901)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00240.xml
+++ b/level1/SLV00240.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Slučaji usode : edicija ELTeC</title>
-            <author ref="viaf:260393202">Pajk, Pavlina (1854-1901)</author>
+            <title ref="wikidata:Q111072127">Slučaji usode : edicija ELTeC</title>
+            <author ref="viaf:260393202 wikidata:Q14428732">Pajk, Pavlina (1854-1901)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00273.xml
+++ b/level1/SLV00273.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Kvišku : edicija ELTeC</title>
-            <author ref="viaf:56648253">Finžgar, Fran Saleški (1871-1962)</author>
+            <title ref="wikidata:Q111071940">Kvišku : edicija ELTeC</title>
+            <author ref="viaf:56648253 wikidata:Q972064">Finžgar, Fran Saleški (1871-1962)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00278.xml
+++ b/level1/SLV00278.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Trojka : edicija ELTeC</title>
-            <author ref="viaf:61405029">Detela, Fran (1850-1926)</author>
+            <title ref="wikidata:Q111072162">Trojka : edicija ELTeC</title>
+            <author ref="viaf:61405029 wikidata:Q5478131">Detela, Fran (1850-1926)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00279.xml
+++ b/level1/SLV00279.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Cvet in sad : edicija ELTeC</title>
-            <author ref="viaf:54483391">Jurčič, Josip (1844-1881)</author>
+            <title ref="wikidata:Q111071782">Cvet in sad : edicija ELTeC</title>
+            <author ref="viaf:54483391 wikidata:Q3491574">Jurčič, Josip (1844-1881)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00310.xml
+++ b/level1/SLV00310.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Potresna povest : edicija ELTeC</title>
-            <author ref="viaf:24474637">Maselj Podlimbarski, Fran (1852-1917)</author>
+            <title ref="wikidata:Q111072103">Potresna povest : edicija ELTeC</title>
+            <author ref="viaf:24474637 wikidata:Q4283778">Maselj Podlimbarski, Fran (1852-1917)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00324.xml
+++ b/level1/SLV00324.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Cvetje v jeseni : edicija ELTeC</title>
-            <author ref="viaf:100298803">Tavčar, Ivan (1851-1923)</author>
+            <title ref="wikidata:Q12787178">Cvetje v jeseni : edicija ELTeC</title>
+            <author ref="viaf:100298803 wikidata:Q700898">Tavčar, Ivan (1851-1923)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00325.xml
+++ b/level1/SLV00325.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Štefan Zaplotnik : edicija ELTeC</title>
-            <author ref="viaf:316497598">Šorli, Ivo (1877-1958)</author>
+            <title ref="wikidata:Q111072149">Štefan Zaplotnik : edicija ELTeC</title>
+            <author ref="viaf:316497598 wikidata:Q12791738">Šorli, Ivo (1877-1958)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00345.xml
+++ b/level1/SLV00345.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Blagorodje doktor Ambrož Čander : edicija ELTeC</title>
-            <author ref="viaf:53731964">Levstik, Vladimir (1886-1957)</author>
+            <title ref="wikidata:Q111071759">Blagorodje doktor Ambrož Čander : edicija ELTeC</title>
+            <author ref="viaf:53731964 wikidata:Q167391">Levstik, Vladimir (1886-1957)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00352.xml
+++ b/level1/SLV00352.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Komisarjeva hči : edicija ELTeC</title>
-            <author ref="viaf:170052698">Fatur, Lea (1865-1943)</author>
+            <title ref="wikidata:Q111071917">Komisarjeva hči : edicija ELTeC</title>
+            <author ref="viaf:170052698 wikidata:Q11753382">Fatur, Lea (1865-1943)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00355.xml
+++ b/level1/SLV00355.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Mlada ljubezen : edicija ELTeC</title>
-            <author ref="viaf:44335953">Kraigher, Alojz (1877-1959)</author>
+            <title ref="wikidata:Q111072019">Mlada ljubezen : edicija ELTeC</title>
+            <author ref="viaf:44335953 wikidata:Q17350627">Kraigher, Alojz (1877-1959)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00363.xml
+++ b/level1/SLV00363.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Malo življenje : edicija ELTeC</title>
-            <author ref="viaf:61405029">Detela, Fran (1850-1926)</author>
+            <title ref="wikidata:Q111073397">Malo življenje : edicija ELTeC</title>
+            <author ref="viaf:61405029 wikidata:Q5478131">Detela, Fran (1850-1926)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00364.xml
+++ b/level1/SLV00364.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Novo življenje : edicija ELTeC</title>
-            <author ref="viaf:61405029">Detela, Fran (1850-1926)</author>
+            <title ref="wikidata:Q111072073">Novo življenje : edicija ELTeC</title>
+            <author ref="viaf:61405029 wikidata:Q5478131">Detela, Fran (1850-1926)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00373.xml
+++ b/level1/SLV00373.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>O, ta testament : edicija ELTeC</title>
-            <author ref="viaf:55376955">Jaklič, Fran (1868-1937)</author>
+            <title ref="wikidata:Q111072075">O, ta testament : edicija ELTeC</title>
+            <author ref="viaf:55376955 wikidata:Q12789003">Jaklič, Fran (1868-1937)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00391.xml
+++ b/level1/SLV00391.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Pisana mati : edicija ELTeC</title>
-            <author ref="viaf:84281491">Zbašnik, Fran (1855-1935)</author>
+            <title ref="wikidata:Q111072088">Pisana mati : edicija ELTeC</title>
+            <author ref="viaf:84281491 wikidata:Q17351194">Zbašnik, Fran (1855-1935)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00398.xml
+++ b/level1/SLV00398.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Martin Kačur : edicija ELTeC</title>
-            <author ref="viaf:56657726">Cankar, Ivan (1876-1918)</author>
+            <title ref="wikidata:Q1904221">Martin Kačur : edicija ELTeC</title>
+            <author ref="viaf:56657726 wikidata:Q15809">Cankar, Ivan (1876-1918)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00401.xml
+++ b/level1/SLV00401.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Na klancu : edicija ELTeC</title>
-            <author ref="viaf:56657726">Cankar, Ivan (1876-1918)</author>
+            <title ref="wikidata:Q3869763">Na klancu : edicija ELTeC</title>
+            <author ref="viaf:56657726 wikidata:Q15809">Cankar, Ivan (1876-1918)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00406.xml
+++ b/level1/SLV00406.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Izza kongresa : edicija ELTeC</title>
-            <author ref="viaf:100298803">Tavčar, Ivan (1851-1923)</author>
+            <title ref="wikidata:Q111071904">Izza kongresa : edicija ELTeC</title>
+            <author ref="viaf:100298803 wikidata:Q700898">Tavčar, Ivan (1851-1923)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00410.xml
+++ b/level1/SLV00410.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Tujci : edicija ELTeC</title>
-            <author ref="viaf:56657726">Cankar, Ivan (1876-1918)</author>
+            <title ref="wikidata:Q111072164">Tujci : edicija ELTeC</title>
+            <author ref="viaf:56657726 wikidata:Q15809">Cankar, Ivan (1876-1918)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00417.xml
+++ b/level1/SLV00417.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Tlačani : edicija ELTeC</title>
-            <author ref="viaf:22231284">Pregelj, Ivan (1883-1960)</author>
+            <title ref="wikidata:Q111072159">Tlačani : edicija ELTeC</title>
+            <author ref="viaf:22231284 wikidata:Q579636">Pregelj, Ivan (1883-1960)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00421.xml
+++ b/level1/SLV00421.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Temni oblaki : edicija ELTeC</title>
-            <author ref="viaf:16146824501407630124">Trošt, Ivo (1865-1937)</author>
+            <title ref="wikidata:Q111072157">Temni oblaki : edicija ELTeC</title>
+            <author ref="viaf:16146824501407630124 wikidata:Q17351181">Trošt, Ivo (1865-1937)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00425.xml
+++ b/level1/SLV00425.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Na vojvodskem prestolu : edicija ELTeC</title>
-            <author ref="viaf:68284771">Gruden, Josip (1869-1922)</author>
+            <title ref="wikidata:Q111072053">Na vojvodskem prestolu : edicija ELTeC</title>
+            <author ref="viaf:68284771 wikidata:Q12792696">Gruden, Josip (1869-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00452.xml
+++ b/level1/SLV00452.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Naš stari greh : edicija ELTeC</title>
-            <author ref="viaf:3285157470199222640002">Prelesnik, Matija (1872-1905)</author>
+            <title ref="wikidata:Q111072065">Naš stari greh : edicija ELTeC</title>
+            <author ref="viaf:3285157470199222640002 wikidata:Q22995458">Prelesnik, Matija (1872-1905)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00454.xml
+++ b/level1/SLV00454.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>V smrtni senci : edicija ELTeC</title>
-            <author ref="viaf:3285157470199222640002">Prelesnik, Matija (1872-1905)</author>
+            <title ref="wikidata:Q111072177">V smrtni senci : edicija ELTeC</title>
+            <author ref="viaf:3285157470199222640002 wikidata:Q22995458">Prelesnik, Matija (1872-1905)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00455.xml
+++ b/level1/SLV00455.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Kralj Matjaž : edicija ELTeC</title>
-            <author ref="viaf:233014487">Malovrh, Miroslav (1861-1922)</author>
+            <title ref="wikidata:Q20522229">Kralj Matjaž : edicija ELTeC</title>
+            <author ref="viaf:233014487 wikidata:Q11781716">Malovrh, Miroslav (1861-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00456.xml
+++ b/level1/SLV00456.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Ljubezen in junaštva strahopetnega praporščaka : edicija ELTeC</title>
-            <author ref="viaf:233014487">Malovrh, Miroslav (1861-1922)</author>
+            <title ref="wikidata:Q111071948">Ljubezen in junaštva strahopetnega praporščaka : edicija ELTeC</title>
+            <author ref="viaf:233014487 wikidata:Q11781716">Malovrh, Miroslav (1861-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00458.xml
+++ b/level1/SLV00458.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Pod novim orlom : edicija ELTeC</title>
-            <author ref="viaf:233014487">Malovrh, Miroslav (1861-1922)</author>
+            <title ref="wikidata:Q111072091">Pod novim orlom : edicija ELTeC</title>
+            <author ref="viaf:233014487 wikidata:Q11781716">Malovrh, Miroslav (1861-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00459.xml
+++ b/level1/SLV00459.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Strahovalci dveh kron : edicija ELTeC</title>
-            <author ref="viaf:233014487">Malovrh, Miroslav (1861-1922)</author>
+            <title ref="wikidata:Q111072153">Strahovalci dveh kron : edicija ELTeC</title>
+            <author ref="viaf:233014487 wikidata:Q11781716">Malovrh, Miroslav (1861-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00460.xml
+++ b/level1/SLV00460.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>V študentskih ulicah : edicija ELTeC</title>
-            <author ref="viaf:233014487">Malovrh, Miroslav (1861-1922)</author>
+            <title ref="wikidata:Q111072180">V študentskih ulicah : edicija ELTeC</title>
+            <author ref="viaf:233014487 wikidata:Q11781716">Malovrh, Miroslav (1861-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00461.xml
+++ b/level1/SLV00461.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Zadnji rodovine Benalja : edicija ELTeC</title>
-            <author ref="viaf:233014487">Malovrh, Miroslav (1861-1922)</author>
+            <title ref="wikidata:Q111072200">Zadnji rodovine Benalja : edicija ELTeC</title>
+            <author ref="viaf:233014487 wikidata:Q11781716">Malovrh, Miroslav (1861-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00473.xml
+++ b/level1/SLV00473.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Groga in drugi : edicija ELTeC</title>
-            <author ref="viaf:66026290">Murnik, Rado (1870-1932)</author>
+            <title ref="wikidata:Q111071871">Groga in drugi : edicija ELTeC</title>
+            <author ref="viaf:66026290 wikidata:Q12799766">Murnik, Rado (1870-1932)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00476.xml
+++ b/level1/SLV00476.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Na Bledu : edicija ELTeC</title>
-            <author ref="viaf:66026290">Murnik, Rado (1870-1932)</author>
+            <title ref="wikidata:Q111072044">Na Bledu : edicija ELTeC</title>
+            <author ref="viaf:66026290 wikidata:Q12799766">Murnik, Rado (1870-1932)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00478.xml
+++ b/level1/SLV00478.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Gadje gnezdo : edicija ELTeC</title>
-            <author ref="viaf:53731964">Levstik, Vladimir (1886-1957)</author>
+            <title ref="wikidata:Q20521427">Gadje gnezdo : edicija ELTeC</title>
+            <author ref="viaf:53731964 wikidata:Q167391">Levstik, Vladimir (1886-1957)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00483.xml
+++ b/level1/SLV00483.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Za svobodo in ljubezen : edicija ELTeC</title>
-            <author ref="viaf:53731964">Levstik, Vladimir (1886-1957)</author>
+            <title ref="wikidata:Q111072196">Za svobodo in ljubezen : edicija ELTeC</title>
+            <author ref="viaf:53731964 wikidata:Q167391">Levstik, Vladimir (1886-1957)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00496.xml
+++ b/level1/SLV00496.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Iz modernega sveta : edicija ELTeC</title>
-            <author ref="viaf:56648253">Finžgar, Fran Saleški (1871-1962)</author>
+            <title ref="wikidata:Q111071902">Iz modernega sveta : edicija ELTeC</title>
+            <author ref="viaf:56648253 wikidata:Q972064">Finžgar, Fran Saleški (1871-1962)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00497.xml
+++ b/level1/SLV00497.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Moja duša vasuje : edicija ELTeC</title>
-            <author ref="viaf:56648253">Finžgar, Fran Saleški (1871-1962)</author>
+            <title ref="wikidata:Q111072042">Moja duša vasuje : edicija ELTeC</title>
+            <author ref="viaf:56648253 wikidata:Q972064">Finžgar, Fran Saleški (1871-1962)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00498.xml
+++ b/level1/SLV00498.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Sama : edicija ELTeC</title>
-            <author ref="viaf:56648253">Finžgar, Fran Saleški (1871-1962)</author>
+            <title ref="wikidata:Q12800693">Sama : edicija ELTeC</title>
+            <author ref="viaf:56648253 wikidata:Q972064">Finžgar, Fran Saleški (1871-1962)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00502.xml
+++ b/level1/SLV00502.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>V burji in strasti : edicija ELTeC</title>
-            <author ref="viaf:170052698">Fatur, Lea (1865-1943)</author>
+            <title ref="wikidata:Q111072166">V burji in strasti : edicija ELTeC</title>
+            <author ref="viaf:170052698 wikidata:Q11753382">Fatur, Lea (1865-1943)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00506.xml
+++ b/level1/SLV00506.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Za Adrijo : edicija ELTeC</title>
-            <author ref="viaf:170052698">Fatur, Lea (1865-1943)</author>
+            <title ref="wikidata:Q111072194">Za Adrijo : edicija ELTeC</title>
+            <author ref="viaf:170052698 wikidata:Q11753382">Fatur, Lea (1865-1943)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV00526.xml
+++ b/level1/SLV00526.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Hči grofa Blagaja : edicija ELTeC</title>
-            <author ref="viaf:66026290">Murnik, Rado (1870-1932)</author>
+            <title ref="wikidata:Q111071873">Hči grofa Blagaja : edicija ELTeC</title>
+            <author ref="viaf:66026290 wikidata:Q12799766">Murnik, Rado (1870-1932)</author>
             <respStmt>
                <resp>Pretvorba zapisa Wiki/DjVu v TEI.</resp>
                <resp xml:lang="en">Conversion form Wiki/DjVu to TEI.</resp>

--- a/level1/SLV10001.xml
+++ b/level1/SLV10001.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Hiša Marije Pomočnice : edicija ELTeC</title>
-            <author ref="viaf:56657726">Cankar, Ivan (1876-1918)</author>
+            <title ref="wikidata:Q11166040">Hiša Marije Pomočnice : edicija ELTeC</title>
+            <author ref="viaf:56657726 wikidata:Q15809">Cankar, Ivan (1876-1918)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10002.xml
+++ b/level1/SLV10002.xml
@@ -7,7 +7,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Zadnji dnevi v Ogleju : edicija ELTeC</title>
+            <title ref="wikidata:Q111072198">Zadnji dnevi v Ogleju : edicija ELTeC</title>
             <author ref="viaf:50937590">Carli Lukovič, Alojz (1846-1891)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>

--- a/level1/SLV10003.xml
+++ b/level1/SLV10003.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Sreča v nesreči : edicija ELTeC</title>
-            <author ref="viaf:247997342">Cigler, Janez (1792-1867)</author>
+            <title ref="wikidata:Q12803287">Sreča v nesreči : edicija ELTeC</title>
+            <author ref="viaf:247997342 wikidata:Q12791998">Cigler, Janez (1792-1867)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10004.xml
+++ b/level1/SLV10004.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Nebesa : edicija ELTeC</title>
-            <author ref="viaf:6786157470209622640003">Fajdiga, Ivan (1854-1935)</author>
+            <title ref="wikidata:Q111072067">Nebesa : edicija ELTeC</title>
+            <author ref="viaf:6786157470209622640003 wikidata:Q12791542">Fajdiga, Ivan (1854-1935)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10005.xml
+++ b/level1/SLV10005.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Pod svobodnim soncem : edicija ELTeC</title>
-            <author ref="viaf:56648253">Finžgar, Fran Saleški (1871-1962)</author>
+            <title ref="wikidata:Q2406802">Pod svobodnim soncem : edicija ELTeC</title>
+            <author ref="viaf:56648253 wikidata:Q972064">Finžgar, Fran Saleški (1871-1962)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10006.xml
+++ b/level1/SLV10006.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Žena : edicija ELTeC</title>
-            <author ref="viaf:66265062">Jelenc, Vitomir Feodor (1885-1922)</author>
+            <title ref="wikidata:Q111072206">Žena : edicija ELTeC</title>
+            <author ref="viaf:66265062 wikidata:Q21140592">Jelenc, Vitomir Feodor (1885-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10007.xml
+++ b/level1/SLV10007.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Deseti brat : edicija ELTeC</title>
-            <author ref="viaf:54483391">Jurčič, Josip (1844-1881)</author>
+            <title ref="wikidata:Q3491756">Deseti brat : edicija ELTeC</title>
+            <author ref="viaf:54483391 wikidata:Q3491574">Jurčič, Josip (1844-1881)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10008.xml
+++ b/level1/SLV10008.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Med dvema stoloma : edicija ELTeC</title>
-            <author ref="viaf:54483391">Jurčič, Josip (1844-1881)</author>
+            <title ref="wikidata:Q6804957">Med dvema stoloma : edicija ELTeC</title>
+            <author ref="viaf:54483391 wikidata:Q3491574">Jurčič, Josip (1844-1881)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10009.xml
+++ b/level1/SLV10009.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Doktor Zober : edicija ELTeC</title>
-            <author ref="viaf:54483391">Jurčič, Josip (1844-1881)</author>
+            <title ref="wikidata:Q111071819">Doktor Zober : edicija ELTeC</title>
+            <author ref="viaf:54483391 wikidata:Q3491574">Jurčič, Josip (1844-1881)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10010.xml
+++ b/level1/SLV10010.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Ivan Erazem Tatenbah : edicija ELTeC</title>
-            <author ref="viaf:54483391">Jurčič, Josip (1844-1881)</author>
+            <title ref="wikidata:Q11109450">Ivan Erazem Tatenbah : edicija ELTeC</title>
+            <author ref="viaf:54483391 wikidata:Q3491574">Jurčič, Josip (1844-1881)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10011.xml
+++ b/level1/SLV10011.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Lepa Vida : edicija ELTeC</title>
-            <author ref="viaf:54483391">Jurčič, Josip (1844-1881)</author>
+            <title ref="wikidata:Q111071943">Lepa Vida : edicija ELTeC</title>
+            <author ref="viaf:54483391 wikidata:Q3491574">Jurčič, Josip (1844-1881)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10012.xml
+++ b/level1/SLV10012.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Kmetski triumvirat : edicija ELTeC</title>
-            <author ref="viaf:172847595">Koder, Anton (1851-1918)</author>
+            <title ref="wikidata:Q111071913">Kmetski triumvirat : edicija ELTeC</title>
+            <author ref="viaf:172847595 wikidata:Q12784821">Koder, Anton (1851-1918)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10013.xml
+++ b/level1/SLV10013.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Mladi gozdar : edicija ELTeC</title>
-            <author ref="viaf:81042077">Kovačič, Ivo (1873-1936)</author>
+            <title ref="wikidata:Q111072022">Mladi gozdar : edicija ELTeC</title>
+            <author ref="viaf:81042077 wikidata:Q57736961">Kovačič, Ivo (1873-1936)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10014.xml
+++ b/level1/SLV10014.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Nada : edicija ELTeC</title>
-            <author ref="viaf:1223577">Kveder, Zofka (1878-1926)</author>
+            <title ref="wikidata:Q111072063">Nada : edicija ELTeC</title>
+            <author ref="viaf:1223577 wikidata:Q112919">Kveder, Zofka (1878-1926)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10015.xml
+++ b/level1/SLV10015.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Njeno življenje : edicija ELTeC</title>
-            <author ref="viaf:1223577">Kveder, Zofka (1878-1926)</author>
+            <title ref="wikidata:Q111072070">Njeno življenje : edicija ELTeC</title>
+            <author ref="viaf:1223577 wikidata:Q112919">Kveder, Zofka (1878-1926)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10016.xml
+++ b/level1/SLV10016.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Zadnji samotar : edicija ELTeC</title>
-            <author ref="viaf:32798590">Mahnič, Anton (1850-1920)</author>
+            <title ref="wikidata:Q111072202">Zadnji samotar : edicija ELTeC</title>
+            <author ref="viaf:32798590 wikidata:Q344599">Mahnič, Anton (1850-1920)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10017.xml
+++ b/level1/SLV10017.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Tolovajski glavar Črni Jurij in njegovi divji tovariši : edicija ELTeC</title>
-            <author ref="viaf:233014487">Malovrh, Miroslav (1861-1922)</author>
+            <title ref="wikidata:Q111072160">Tolovajski glavar Črni Jurij in njegovi divji tovariši : edicija ELTeC</title>
+            <author ref="viaf:233014487 wikidata:Q11781716">Malovrh, Miroslav (1861-1922)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10018.xml
+++ b/level1/SLV10018.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Gospodin Franjo : edicija ELTeC</title>
-            <author ref="viaf:24474637">Maselj Podlimbarski, Fran (1852-1917)</author>
+            <title ref="wikidata:Q5587428">Gospodin Franjo : edicija ELTeC</title>
+            <author ref="viaf:24474637 wikidata:Q4283778">Maselj Podlimbarski, Fran (1852-1917)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10019.xml
+++ b/level1/SLV10019.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Ptički brez gnezda : edicija ELTeC</title>
-            <author ref="viaf:72324490">Milčinski, Fran (1867-1932)</author>
+            <title ref="wikidata:Q111072105">Ptički brez gnezda : edicija ELTeC</title>
+            <author ref="viaf:72324490 wikidata:Q11313830">Milčinski, Fran (1867-1932)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10020.xml
+++ b/level1/SLV10020.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Fata morgana : edicija ELTeC</title>
-            <author ref="viaf:6737472">Nadlišek, Marica (1867-1940)</author>
+            <title ref="wikidata:Q111071824">Fata morgana : edicija ELTeC</title>
+            <author ref="viaf:6737472 wikidata:Q12795693">Nadlišek, Marica (1867-1940)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10021.xml
+++ b/level1/SLV10021.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Judita : edicija ELTeC</title>
-            <author ref="viaf:260393202">Pajk, Pavlina (1854-1901)</author>
+            <title ref="wikidata:Q111071907">Judita : edicija ELTeC</title>
+            <author ref="viaf:260393202 wikidata:Q14428732">Pajk, Pavlina (1854-1901)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10022.xml
+++ b/level1/SLV10022.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Mina : edicija ELTeC</title>
-            <author ref="viaf:79068165">Prepeluh, Albin (1881-1937)</author>
+            <title ref="wikidata:Q111072016">Mina : edicija ELTeC</title>
+            <author ref="viaf:79068165 wikidata:Q4712384">Prepeluh, Albin (1881-1937)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10023.xml
+++ b/level1/SLV10023.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Zorin : edicija ELTeC</title>
-            <author ref="viaf:70948422">Stritar, Josip (1836-1923)</author>
+            <title ref="wikidata:Q111072209">Zorin : edicija ELTeC</title>
+            <author ref="viaf:70948422 wikidata:Q1397983">Stritar, Josip (1836-1923)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10024.xml
+++ b/level1/SLV10024.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Sodnikovi : edicija ELTeC</title>
-            <author ref="viaf:70948422">Stritar, Josip (1836-1923)</author>
+            <title ref="wikidata:Q111072129">Sodnikovi : edicija ELTeC</title>
+            <author ref="viaf:70948422 wikidata:Q1397983">Stritar, Josip (1836-1923)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10025.xml
+++ b/level1/SLV10025.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Gospod Mirodolski : edicija ELTeC</title>
-            <author ref="viaf:70948422">Stritar, Josip (1836-1923)</author>
+            <title ref="wikidata:Q111071852">Gospod Mirodolski : edicija ELTeC</title>
+            <author ref="viaf:70948422 wikidata:Q1397983">Stritar, Josip (1836-1923)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10026.xml
+++ b/level1/SLV10026.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Visoška kronika : edicija ELTeC</title>
-            <author ref="viaf:100298803">Tavčar, Ivan (1851-1923)</author>
+            <title ref="wikidata:Q17391366">Visoška kronika : edicija ELTeC</title>
+            <author ref="viaf:100298803 wikidata:Q700898">Tavčar, Ivan (1851-1923)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10027.xml
+++ b/level1/SLV10027.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Libera nos a malo : edicija ELTeC</title>
-            <author ref="viaf:6604157470209022640002">Vodeb, Emil (1880-1921)</author>
+            <title ref="wikidata:Q111071946">Libera nos a malo : edicija ELTeC</title>
+            <author ref="viaf:6604157470209022640002 wikidata:Q23010732">Vodeb, Emil (1880-1921)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10028.xml
+++ b/level1/SLV10028.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Pobratimi : edicija ELTeC</title>
-            <author ref="viaf:55300280">Vošnjak, Josip (1834-1911)</author>
+            <title ref="wikidata:Q111072090">Pobratimi : edicija ELTeC</title>
+            <author ref="viaf:55300280 wikidata:Q5242758">Vošnjak, Josip (1834-1911)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10029.xml
+++ b/level1/SLV10029.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Rošlin in Vrjanko : edicija ELTeC</title>
-            <author ref="viaf:34746806">Kersnik, Janko (1852-1897)</author>
+            <title ref="wikidata:Q111072115">Rošlin in Vrjanko : edicija ELTeC</title>
+            <author ref="viaf:34746806 wikidata:Q2474110">Kersnik, Janko (1852-1897)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10030.xml
+++ b/level1/SLV10030.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Svitanje : edicija ELTeC</title>
-            <author ref="viaf:51812691">Govekar, Fran (1871-1949)</author>
+            <title ref="wikidata:Q111072155">Svitanje : edicija ELTeC</title>
+            <author ref="viaf:51812691 wikidata:Q12788999">Govekar, Fran (1871-1949)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10031.xml
+++ b/level1/SLV10031.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Brambovci : edicija ELTeC</title>
-            <author ref="viaf:101581601">Lah, Ivan (1881-1938)</author>
+            <title ref="wikidata:Q111071762">Brambovci : edicija ELTeC</title>
+            <author ref="viaf:101581601 wikidata:Q12791587">Lah, Ivan (1881-1938)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV10032.xml
+++ b/level1/SLV10032.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Z viharja v zavetje : edicija ELTeC</title>
-            <author ref="viaf:84281491">Zbašnik, Fran (1855-1935)</author>
+            <title ref="wikidata:Q111072193">Z viharja v zavetje : edicija ELTeC</title>
+            <author ref="viaf:84281491 wikidata:Q17351194">Zbašnik, Fran (1855-1935)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV20001.xml
+++ b/level1/SLV20001.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Mlinarjev Janez : edicija ELTeC</title>
-            <author ref="viaf:172466996">Kočevar, Ferdo (1833-1878)</author>
+            <title ref="wikidata:Q20522082">Mlinarjev Janez : edicija ELTeC</title>
+            <author ref="viaf:172466996 wikidata:Q12788832">Kočevar, Ferdo (1833-1878)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV20002.xml
+++ b/level1/SLV20002.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Miklova Zala : edicija ELTeC</title>
-            <author ref="viaf:93569857">Sket, Jakob (1852-1912)</author>
+            <title ref="wikidata:Q111072011">Miklova Zala : edicija ELTeC</title>
+            <author ref="viaf:93569857 wikidata:Q1679356">Sket, Jakob (1852-1912)</author>
             <respStmt>
                <resp>Pretvorba zapisa WikiVir v ELTeC.</resp>
                <resp xml:lang="en">Conversion from WikiVir to ELTeC encoding.</resp>

--- a/level1/SLV30001.xml
+++ b/level1/SLV30001.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>S poti : edicija ELTeC</title>
-            <author ref="viaf:51848354">Cankar, Izidor (1886-1958)</author>
+            <title ref="wikidata:Q111072117">S poti : edicija ELTeC</title>
+            <author ref="viaf:51848354 wikidata:Q12054170">Cankar, Izidor (1886-1958)</author>
             <respStmt>
                <resp>Pretvorba zapisa eZISS v ELTeC.</resp>
                <resp xml:lang="en">Conversion from eZISS TEI to ELTeC encoding.</resp>


### PR DESCRIPTION
Added wikidata:QXXXXX identifiers to the ref attribute of <title> and <author> elements in <titleStmt> for all 100 level1 texts. Author IDs added: 97 | Work IDs added: 100
Wikidata IDs obtained via SPARQL (author: VIAF lookup; work: Slovenian @sl label search).